### PR TITLE
Add missing "this object" code for Content Index health checks

### DIFF
--- a/Test-ExchangeServerHealth.ps1
+++ b/Test-ExchangeServerHealth.ps1
@@ -1525,10 +1525,10 @@ if ($($dags.count) -gt 0)
             $laggedqueues = @($copies | Where-Object { ($_."Replay Lagged" -eq $true) -or ($_."Truncation Lagged" -eq $true) }).Count
             $databaseObj | Add-Member NoteProperty -Name "Lagged Queues" -Value $laggedqueues -Force
 
-            $healthyindexes = @($copies | Where-Object { ($_."Content Index" -eq "Healthy" -or $_."Content Index" -eq "Disabled" -or "Content Index" -eq "AutoSuspended") }).Count
+            $healthyindexes = @($copies | Where-Object { ($_."Content Index" -eq "Healthy" -or $_."Content Index" -eq "Disabled" -or $_."Content Index" -eq "AutoSuspended") }).Count
             $databaseObj | Add-Member NoteProperty -Name "Healthy Indexes" -Value $healthyindexes -Force
             
-            $unhealthyindexes = @($copies | Where-Object { ($_."Content Index" -ne "Healthy" -and $_."Content Index" -ne "Disabled" -and "Content Index" -ne "AutoSuspended") }).Count
+            $unhealthyindexes = @($copies | Where-Object { ($_."Content Index" -ne "Healthy" -and $_."Content Index" -ne "Disabled" -and $_."Content Index" -ne "AutoSuspended") }).Count
             $databaseObj | Add-Member NoteProperty -Name "Unhealthy Indexes" -Value $unhealthyindexes -Force
             
             $dagdatabaseSummary += $databaseObj


### PR DESCRIPTION
$_. was missing from two comparisons on AutoSuspended Content Indexes