### PR TITLE
Add initial support for Exchange 2019

### DIFF
--- a/Test-ExchangeServerHealth.ps1
+++ b/Test-ExchangeServerHealth.ps1
@@ -843,6 +843,12 @@ foreach ($server in $exchangeservers)
                 {
                     $version = "Exchange 2016"
                 }
+				
+				if ($ExVer -like "Version 15.2*")
+                {
+                    $version = "Exchange 2019"
+                }
+				
                 
                 Write-Host $version
                 if ($Log) {Write-Logfile "Server is running $version"}
@@ -1424,7 +1430,11 @@ if ($($dags.count) -gt 0)
                 {
                     $contentindexstate = "Disabled"
                 }
-                else
+                elseif ($($dbcopy.ContentIndexState -match "NotApplicable") -or $($dbcopy.ContentIndexState -match "11" ))
+                {
+                    $contentindexstate = "Healthy"
+                }
+				else
                 {
                     $contentindexstate = $dbcopy.ContentIndexState
                 }


### PR DESCRIPTION
Added basic support for Exchange 2019 detection and handling ContentIndexState no longer existing in Exchange 2019 - when you query it from Exchange 2019 it reports back as NotApplicable but when you query from an Exchange 2013 server it returns ContentIndexState as 11 instead so I have caught both of these.

I've not tested on 2016 as I don't run this, presumably it will return as either 2013 or 2019 do though.

Currently I'm just reporting 2019's ContentIndexState as just Healthy so it shows nicely as green but I guess this could be changed to show as Not Applicable and still show as green if preferred (this was just a quick hack to get the report working).