### PR TITLE
Update for Exchange 2016 CU 15 ActivationPreference

### DIFF
--- a/Test-ExchangeServerHealth.ps1
+++ b/Test-ExchangeServerHealth.ps1
@@ -1406,7 +1406,9 @@ if ($($dags.count) -gt 0)
                 Write-Verbose $tmpstring
                 if ($Log) {Write-Logfile $tmpstring}
 
-                $pref = ($database | Select-Object -ExpandProperty ActivationPreference | Where-Object {$_.Key -ieq $mailboxserver}).Value
+                # Not sure how to correct the activation preference see my comments - CKH
+		
+		$pref = ($database | Select-Object -ExpandProperty ActivationPreference | Where-Object {$_.Key -ieq $mailboxserver}).Value
                 $tmpstring = "Activation Preference: $pref"
                 Write-Verbose $tmpstring
                 if ($Log) {Write-Logfile $tmpstring}


### PR DESCRIPTION
Hello. I have upgraded to Exchange 2016 CU 15 and the Activation Preference is no longer showing.

The line in the script that gets the Activation Preference i is not getting the preference.

$pref = ($database | Select-Object -ExpandProperty ActivationPreference | Where-Object {$_.Key -ieq $mailboxserver}).Value

If I run the script using an Exchange 2010 shell is works but not when it is Exchange 2016. Can someone help me fix the script so I get the preference again.